### PR TITLE
fix: Resolved Prettier CR line ending issue

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+# Editor configuration, see http://editorconfig.org
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true


### PR DESCRIPTION
## Description
This PR fixed #32 by adding a `.editorconfig` file to the project to help maintain consistent coding styles across different editors and OS. The settings applied are as follows:
- end_of_line = lf: Forces Unix-style (\n) line endings for all files.
- insert_final_newline = true: Ensures every file ends with a newline.
