### PR TITLE
chore: Enforced LF line endings across platforms

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto eol=lf


### PR DESCRIPTION
## Description
This PR adds a `.gitattributes` file to enforce consistent LF (Unix-style) line endings across all environments, including Windows. Developers on Windows were experiencing issues where pulling the codebase would result in CRLF line endings. This caused `npm run lint` to report line break errors and required unnecessary file modifications when running `npm run lint -- --fix`.