### PR TITLE
chore: Renamed vite base URL

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
       - main
 
 env:
-  VITE_DISPATCHER_API_URL: ${{ secrets.VITE_DISPATCHER_API_URL }}
+  VITE_BACKEND_BASE_URL: ${{ secrets.VITE_BACKEND_BASE_URL }}
 
 jobs:
   build:

--- a/src/services/earthquake.js
+++ b/src/services/earthquake.js
@@ -1,5 +1,5 @@
 import axios from "axios";
-const baseUrl = `${import.meta.env.VITE_DISPATCHER_API_URL}`;
+const baseUrl = `${import.meta.env.VITE_BACKEND_BASE_URL}`;
 
 const create = (newObject) => {
   return axios.post(baseUrl, newObject);


### PR DESCRIPTION
## Description
This PR renames the environment variable `VITE_DISPATCHER_API_URL` to `VITE_BACKEND_BASE_URL` to better reflect its purpose as the base URL for backend API requests.