### PR TITLE
chore: Renamed GAR repo name

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ on:
 
 env:
   REGION_NAME: asia-east1-docker.pkg.dev
-  REPO_NAME: images-repo
+  REPO_NAME: app-images
   IMAGE_NAME: simulation-ui
   PROJECT_ID: tsmc-ntu-g4
 


### PR DESCRIPTION
## Description
This PR updates the `REPO_NAME` environment variable in the deploy workflow file, renaming it from `images-repo` to `app-images` for better clarity.